### PR TITLE
Go: T4472: Added compatibility with new Go versions

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Maintainer: VyOS Package Maintainers <maintainers@vyos.net>
 Homepage: https://github.com/xenserver
 Standards-Version: 4.1.4
-Build-Depends: debhelper (>= 12), gawk, golang
+Build-Depends: debhelper (>= 12), gawk
 Vcs-Git: https://github.com/xenserver/xe-guest-utilities
 
 Package: vyos-xe-guest-utilities

--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,9 @@
 #!/usr/bin/make -f
 #export DH_VERBOSE=1
 
+# Disable module-aware mode, required for compatibility with Go 1.16+
+export GO111MODULE=off
+
 %:
 	dh $@ --with systemd
 


### PR DESCRIPTION
* removed dependency from `golang` package with an old version
* added environment variable to disable module-aware mode in Go 1.16+, to make build possible using latest Go